### PR TITLE
fix: blob api doc is confusing

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Blob.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Blob.java
@@ -63,6 +63,15 @@ import java.util.concurrent.TimeUnit;
  * {@link #copyTo} return a new object. Any changes to a Storage object made after creation of the
  * {@code Blob} is not visible in the {@code Blob}. To get a {@code Blob} object with the most
  * recent information use {@link #reload}.
+ *
+ * <p>Example of getting the content of a Storage object:
+ *
+ * <pre>{@code
+ * BlobId blobId = BlobId.of(bucketName, blobName);
+ * Blob blob = storage.get(blobId);
+ * long size = blob.getSize(); // no RPC call is required
+ * byte[] content = blob.getContent(); // one or multiple RPC calls will be issued
+ * }</pre>
  */
 public class Blob extends BlobInfo {
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Blob.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Blob.java
@@ -52,12 +52,17 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /**
- * A Google cloud storage object.
+ * A Google cloud storage object. A {@code Blob} object includes the {@code BlobId} instance, the
+ * set of properties inherited from the {@link BlobInfo} class and the {@code Storage} instance. The
+ * class provides methods to perform operations on the object. Reading a property value does not
+ * issue any RPC calls. The object content is not stored within the {@code Blob} instance,
+ * operations on obtaining the content will issue one or multiple RPC calls, depending on the
+ * content size.
  *
  * <p>Objects of this class are immutable. Operations that modify the blob like {@link #update} and
- * {@link #copyTo} return a new object. To get a {@code Blob} object with the most recent
- * information use {@link #reload}. {@code Blob} adds a layer of service-related functionality over
- * {@link BlobInfo}.
+ * {@link #copyTo} return a new object. Any changes to a Storage object made after creation of the
+ * {@code Blob} is not visible in the {@code Blob}. To get a {@code Blob} object with the most
+ * recent information use {@link #reload}.
  */
 public class Blob extends BlobInfo {
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobInfo.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobInfo.java
@@ -44,7 +44,21 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * Google Storage object metadata.
+ * Google Storage object information. A {@code BlobInfo} object includes the {@code BlobId} instance
+ * and the set of properties, such as the blob's access control configuration, user provided
+ * metadata, the CRC32C checksum, etc. Instances of this class are used to create a new Storage
+ * object or update the properties of an existing object. To deal with existing Storage objects the
+ * API includes the {@link Blob} class which extends {@code BlobInfo} and declares methods to
+ * perform operations on the object. Neither {@code BlobInfo} nor {@code Blob} instances keep the
+ * object content, just the object properties.
+ *
+ * <p>Example of usage {@code BlobInfo} to crate a Storage object:
+ *
+ * <pre>{@code
+ * BlobId blobId = BlobId.of(bucketName, blobName);
+ * BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType("text/plain").build();
+ * Blob blob = storage.create(blobInfo, "Hello, world".getBytes(StandardCharsets.UTF_8));
+ * }</pre>
  *
  * @see <a href="https://cloud.google.com/storage/docs/concepts-techniques#concepts">Concepts and
  *     Terminology</a>


### PR DESCRIPTION
Changes to the Javadoc of the Blob and BlobInfo classes.
