### PR TITLE
feat: update upload to return blob

### DIFF
--- a/google-cloud-storage/clirr-ignored-differences.xml
+++ b/google-cloud-storage/clirr-ignored-differences.xml
@@ -4,11 +4,23 @@
   <difference>
     <differenceType>7012</differenceType>
     <className>com/google/cloud/storage/Storage</className>
-    <method>void upload(*.BlobInfo, java.nio.file.Path, *.Storage$BlobWriteOption[])</method>
+    <method>*.Blob upload(*.BlobInfo, java.nio.file.Path, *.Storage$BlobWriteOption[])</method>
   </difference>
   <difference>
     <differenceType>7012</differenceType>
     <className>com/google/cloud/storage/Storage</className>
-    <method>void upload(*.BlobInfo, java.io.InputStream, *.Storage$BlobWriteOption[])</method>
+    <method>*.Blob upload(*.BlobInfo, java.io.InputStream, *.Storage$BlobWriteOption[])</method>
+  </difference>
+  <difference>
+    <differenceType>7006</differenceType>
+    <className>com/google/cloud/storage/spi/v1/StorageRpc</className>
+    <method>void write(*.String, byte[], int, long, int, boolean)</method>
+    <to>com.google.api.services.storage.model.StorageObject</to>
+  </difference>
+  <difference>
+    <differenceType>7006</differenceType>
+    <className>com/google/cloud/storage/spi/v1/HttpStorageRpc</className>
+    <method>void write(*.String, byte[], int, long, int, boolean)</method>
+    <to>com.google.api.services.storage.model.StorageObject</to>
   </difference>
 </differences>

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobWriteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobWriteChannel.java
@@ -19,6 +19,7 @@ package com.google.cloud.storage;
 import static com.google.cloud.RetryHelper.runWithRetries;
 import static java.util.concurrent.Executors.callable;
 
+import com.google.api.services.storage.model.StorageObject;
 import com.google.cloud.BaseWriteChannel;
 import com.google.cloud.RestorableState;
 import com.google.cloud.RetryHelper;
@@ -47,6 +48,13 @@ class BlobWriteChannel extends BaseWriteChannel<StorageOptions, BlobInfo> {
     super(options, null, uploadId);
   }
 
+  // Contains metadata of the updated object or null if upload is not completed.
+  private StorageObject objectProto;
+
+  StorageObject getObjectProto() {
+    return objectProto;
+  }
+
   @Override
   protected void flushBuffer(final int length, final boolean last) {
     try {
@@ -55,9 +63,10 @@ class BlobWriteChannel extends BaseWriteChannel<StorageOptions, BlobInfo> {
               new Runnable() {
                 @Override
                 public void run() {
-                  getOptions()
-                      .getStorageRpcV1()
-                      .write(getUploadId(), getBuffer(), 0, getPosition(), length, last);
+                  objectProto =
+                      getOptions()
+                          .getStorageRpcV1()
+                          .write(getUploadId(), getBuffer(), 0, getPosition(), length, last);
                 }
               }),
           getOptions().getRetrySettings(),

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
@@ -1720,7 +1720,7 @@ public interface Storage extends Service<StorageOptions> {
    * Blob blob = storage.create(blobInfo);
    * }</pre>
    *
-   * @return a [@code Blob} with complete information
+   * @return a {@code Blob} with complete information
    * @throws StorageException upon failure
    */
   Blob create(BlobInfo blobInfo, BlobTargetOption... options);
@@ -1741,7 +1741,7 @@ public interface Storage extends Service<StorageOptions> {
    * Blob blob = storage.create(blobInfo, "Hello, World!".getBytes(UTF_8));
    * }</pre>
    *
-   * @return a [@code Blob} with complete information
+   * @return a {@code Blob} with complete information
    * @throws StorageException upon failure
    * @see <a href="https://cloud.google.com/storage/docs/hashes-etags">Hashes and ETags</a>
    */
@@ -1764,7 +1764,7 @@ public interface Storage extends Service<StorageOptions> {
    * Blob blob = storage.create(blobInfo, "Hello, World!".getBytes(UTF_8), 7, 5);
    * }</pre>
    *
-   * @return a [@code Blob} with complete information
+   * @return a {@code Blob} with complete information
    * @throws StorageException upon failure
    * @see <a href="https://cloud.google.com/storage/docs/hashes-etags">Hashes and ETags</a>
    */
@@ -1807,7 +1807,7 @@ public interface Storage extends Service<StorageOptions> {
    * Blob blob = storage.create(blobInfo, content, BlobWriteOption.encryptionKey(encryptionKey));
    * }</pre>
    *
-   * @return a [@code Blob} with complete information
+   * @return a {@code Blob} with complete information
    * @throws StorageException upon failure
    */
   @Deprecated
@@ -1832,11 +1832,12 @@ public interface Storage extends Service<StorageOptions> {
    * @param blobInfo blob to create
    * @param path file to upload
    * @param options blob write options
+   * @return a {@code Blob} with complete information
    * @throws IOException on I/O error
    * @throws StorageException on failure
    * @see #upload(BlobInfo, Path, int, BlobWriteOption...)
    */
-  void upload(BlobInfo blobInfo, Path path, BlobWriteOption... options) throws IOException;
+  Blob upload(BlobInfo blobInfo, Path path, BlobWriteOption... options) throws IOException;
 
   /**
    * Uploads {@code path} to the blob using {@link #writer} and {@code bufferSize}. By default any
@@ -1865,10 +1866,11 @@ public interface Storage extends Service<StorageOptions> {
    * @param path file to upload
    * @param bufferSize size of the buffer I/O operations
    * @param options blob write options
+   * @return a {@code Blob} with complete information
    * @throws IOException on I/O error
    * @throws StorageException on failure
    */
-  void upload(BlobInfo blobInfo, Path path, int bufferSize, BlobWriteOption... options)
+  Blob upload(BlobInfo blobInfo, Path path, int bufferSize, BlobWriteOption... options)
       throws IOException;
 
   /**
@@ -1890,11 +1892,12 @@ public interface Storage extends Service<StorageOptions> {
    * @param blobInfo blob to create
    * @param content input stream to read from
    * @param options blob write options
+   * @return a {@code Blob} with complete information
    * @throws IOException on I/O error
    * @throws StorageException on failure
    * @see #upload(BlobInfo, InputStream, int, BlobWriteOption...)
    */
-  void upload(BlobInfo blobInfo, InputStream content, BlobWriteOption... options)
+  Blob upload(BlobInfo blobInfo, InputStream content, BlobWriteOption... options)
       throws IOException;
 
   /**
@@ -1914,10 +1917,11 @@ public interface Storage extends Service<StorageOptions> {
    * @param content input stream to read from
    * @param bufferSize size of the buffer I/O operations
    * @param options blob write options
+   * @return a {@code Blob} with complete information
    * @throws IOException on I/O error
    * @throws StorageException on failure
    */
-  void upload(BlobInfo blobInfo, InputStream content, int bufferSize, BlobWriteOption... options)
+  Blob upload(BlobInfo blobInfo, InputStream content, int bufferSize, BlobWriteOption... options)
       throws IOException;
 
   /**

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
@@ -215,34 +215,39 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage {
   }
 
   @Override
-  public void upload(BlobInfo blobInfo, Path path, BlobWriteOption... options) throws IOException {
-    upload(blobInfo, path, DEFAULT_BUFFER_SIZE, options);
+  public Blob upload(BlobInfo blobInfo, Path path, BlobWriteOption... options) throws IOException {
+    return upload(blobInfo, path, DEFAULT_BUFFER_SIZE, options);
   }
 
   @Override
-  public void upload(BlobInfo blobInfo, Path path, int bufferSize, BlobWriteOption... options)
+  public Blob upload(BlobInfo blobInfo, Path path, int bufferSize, BlobWriteOption... options)
       throws IOException {
     if (Files.isDirectory(path)) {
       throw new StorageException(0, path + " is a directory");
     }
     try (InputStream input = Files.newInputStream(path)) {
-      upload(blobInfo, input, bufferSize, options);
+      return upload(blobInfo, input, bufferSize, options);
     }
   }
 
   @Override
-  public void upload(BlobInfo blobInfo, InputStream content, BlobWriteOption... options)
+  public Blob upload(BlobInfo blobInfo, InputStream content, BlobWriteOption... options)
       throws IOException {
-    upload(blobInfo, content, DEFAULT_BUFFER_SIZE, options);
+    return upload(blobInfo, content, DEFAULT_BUFFER_SIZE, options);
   }
 
   @Override
-  public void upload(
+  public Blob upload(
       BlobInfo blobInfo, InputStream content, int bufferSize, BlobWriteOption... options)
       throws IOException {
+
+    BlobWriteChannel blobWriteChannel;
     try (WriteChannel writer = writer(blobInfo, options)) {
+      blobWriteChannel = (BlobWriteChannel) writer;
       uploadHelper(Channels.newChannel(content), writer, bufferSize);
     }
+    StorageObject objectProto = blobWriteChannel.getObjectProto();
+    return Blob.fromPb(this, objectProto);
   }
 
   /*

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/StorageRpc.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/StorageRpc.java
@@ -313,11 +313,12 @@ public interface StorageRpc extends ServiceRpc {
   String open(String signedURL);
 
   /**
-   * Writes the provided bytes to a storage object at the provided location.
+   * Writes the provided bytes to a storage object at the provided location. If {@code last=true}
+   * returns metadata of the updated object, otherwise returns null.
    *
    * @throws StorageException upon failure
    */
-  void write(
+  StorageObject write(
       String uploadId,
       byte[] toWrite,
       int toWriteOffset,

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BlobWriteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BlobWriteChannelTest.java
@@ -27,10 +27,14 @@ import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.api.services.storage.model.StorageObject;
 import com.google.cloud.RestorableState;
 import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.spi.StorageRpcFactory;
@@ -57,6 +61,7 @@ public class BlobWriteChannelTest {
   private static final String BLOB_NAME = "n";
   private static final String UPLOAD_ID = "uploadid";
   private static final BlobInfo BLOB_INFO = BlobInfo.newBuilder(BUCKET_NAME, BLOB_NAME).build();
+  private static final StorageObject UPDATED_BLOB = new StorageObject();
   private static final Map<StorageRpc.Option, ?> EMPTY_RPC_OPTIONS = ImmutableMap.of();
   private static final int MIN_CHUNK_SIZE = 256 * 1024;
   private static final int DEFAULT_CHUNK_SIZE = 60 * MIN_CHUNK_SIZE; // 15MiB
@@ -94,6 +99,7 @@ public class BlobWriteChannelTest {
     replay(storageRpcMock);
     writer = new BlobWriteChannel(options, BLOB_INFO, EMPTY_RPC_OPTIONS);
     assertTrue(writer.isOpen());
+    assertNull(writer.getObjectProto());
   }
 
   @Test
@@ -104,6 +110,7 @@ public class BlobWriteChannelTest {
     replay(storageRpcMock);
     writer = new BlobWriteChannel(options, BLOB_INFO, EMPTY_RPC_OPTIONS);
     assertTrue(writer.isOpen());
+    assertNull(writer.getObjectProto());
   }
 
   @Test
@@ -131,28 +138,44 @@ public class BlobWriteChannelTest {
   public void testWriteWithFlush() throws IOException {
     expect(storageRpcMock.open(BLOB_INFO.toPb(), EMPTY_RPC_OPTIONS)).andReturn(UPLOAD_ID);
     Capture<byte[]> capturedBuffer = Capture.newInstance();
-    storageRpcMock.write(
-        eq(UPLOAD_ID), capture(capturedBuffer), eq(0), eq(0L), eq(CUSTOM_CHUNK_SIZE), eq(false));
+    expect(
+            storageRpcMock.write(
+                eq(UPLOAD_ID),
+                capture(capturedBuffer),
+                eq(0),
+                eq(0L),
+                eq(CUSTOM_CHUNK_SIZE),
+                eq(false)))
+        .andReturn(null);
     replay(storageRpcMock);
     writer = new BlobWriteChannel(options, BLOB_INFO, EMPTY_RPC_OPTIONS);
     writer.setChunkSize(CUSTOM_CHUNK_SIZE);
     ByteBuffer buffer = randomBuffer(CUSTOM_CHUNK_SIZE);
     assertEquals(CUSTOM_CHUNK_SIZE, writer.write(buffer));
     assertArrayEquals(buffer.array(), capturedBuffer.getValue());
+    assertNull(writer.getObjectProto());
   }
 
   @Test
   public void testWritesAndFlush() throws IOException {
     expect(storageRpcMock.open(BLOB_INFO.toPb(), EMPTY_RPC_OPTIONS)).andReturn(UPLOAD_ID);
     Capture<byte[]> capturedBuffer = Capture.newInstance();
-    storageRpcMock.write(
-        eq(UPLOAD_ID), capture(capturedBuffer), eq(0), eq(0L), eq(DEFAULT_CHUNK_SIZE), eq(false));
+    expect(
+            storageRpcMock.write(
+                eq(UPLOAD_ID),
+                capture(capturedBuffer),
+                eq(0),
+                eq(0L),
+                eq(DEFAULT_CHUNK_SIZE),
+                eq(false)))
+        .andReturn(null);
     replay(storageRpcMock);
     writer = new BlobWriteChannel(options, BLOB_INFO, EMPTY_RPC_OPTIONS);
     ByteBuffer[] buffers = new ByteBuffer[DEFAULT_CHUNK_SIZE / MIN_CHUNK_SIZE];
     for (int i = 0; i < buffers.length; i++) {
       buffers[i] = randomBuffer(MIN_CHUNK_SIZE);
       assertEquals(MIN_CHUNK_SIZE, writer.write(buffers[i]));
+      assertNull(writer.getObjectProto());
     }
     for (int i = 0; i < buffers.length; i++) {
       assertArrayEquals(
@@ -166,13 +189,17 @@ public class BlobWriteChannelTest {
   public void testCloseWithoutFlush() throws IOException {
     expect(storageRpcMock.open(BLOB_INFO.toPb(), EMPTY_RPC_OPTIONS)).andReturn(UPLOAD_ID);
     Capture<byte[]> capturedBuffer = Capture.newInstance();
-    storageRpcMock.write(eq(UPLOAD_ID), capture(capturedBuffer), eq(0), eq(0L), eq(0), eq(true));
+    expect(
+            storageRpcMock.write(
+                eq(UPLOAD_ID), capture(capturedBuffer), eq(0), eq(0L), eq(0), eq(true)))
+        .andReturn(UPDATED_BLOB);
     replay(storageRpcMock);
     writer = new BlobWriteChannel(options, BLOB_INFO, EMPTY_RPC_OPTIONS);
     assertTrue(writer.isOpen());
     writer.close();
     assertArrayEquals(new byte[0], capturedBuffer.getValue());
-    assertTrue(!writer.isOpen());
+    assertFalse(writer.isOpen());
+    assertSame(UPDATED_BLOB, writer.getObjectProto());
   }
 
   @Test
@@ -180,8 +207,15 @@ public class BlobWriteChannelTest {
     expect(storageRpcMock.open(BLOB_INFO.toPb(), EMPTY_RPC_OPTIONS)).andReturn(UPLOAD_ID);
     Capture<byte[]> capturedBuffer = Capture.newInstance();
     ByteBuffer buffer = randomBuffer(MIN_CHUNK_SIZE);
-    storageRpcMock.write(
-        eq(UPLOAD_ID), capture(capturedBuffer), eq(0), eq(0L), eq(MIN_CHUNK_SIZE), eq(true));
+    expect(
+            storageRpcMock.write(
+                eq(UPLOAD_ID),
+                capture(capturedBuffer),
+                eq(0),
+                eq(0L),
+                eq(MIN_CHUNK_SIZE),
+                eq(true)))
+        .andReturn(UPDATED_BLOB);
     replay(storageRpcMock);
     writer = new BlobWriteChannel(options, BLOB_INFO, EMPTY_RPC_OPTIONS);
     assertTrue(writer.isOpen());
@@ -189,14 +223,18 @@ public class BlobWriteChannelTest {
     writer.close();
     assertEquals(DEFAULT_CHUNK_SIZE, capturedBuffer.getValue().length);
     assertArrayEquals(buffer.array(), Arrays.copyOf(capturedBuffer.getValue(), MIN_CHUNK_SIZE));
-    assertTrue(!writer.isOpen());
+    assertFalse(writer.isOpen());
+    assertSame(UPDATED_BLOB, writer.getObjectProto());
   }
 
   @Test
   public void testWriteClosed() throws IOException {
     expect(storageRpcMock.open(BLOB_INFO.toPb(), EMPTY_RPC_OPTIONS)).andReturn(UPLOAD_ID);
     Capture<byte[]> capturedBuffer = Capture.newInstance();
-    storageRpcMock.write(eq(UPLOAD_ID), capture(capturedBuffer), eq(0), eq(0L), eq(0), eq(true));
+    expect(
+            storageRpcMock.write(
+                eq(UPLOAD_ID), capture(capturedBuffer), eq(0), eq(0L), eq(0), eq(true)))
+        .andReturn(UPDATED_BLOB);
     replay(storageRpcMock);
     writer = new BlobWriteChannel(options, BLOB_INFO, EMPTY_RPC_OPTIONS);
     writer.close();
@@ -206,6 +244,7 @@ public class BlobWriteChannelTest {
     } catch (IOException ex) {
       // expected
     }
+    assertSame(UPDATED_BLOB, writer.getObjectProto());
   }
 
   @Test
@@ -213,13 +252,15 @@ public class BlobWriteChannelTest {
     expect(storageRpcMock.open(BLOB_INFO.toPb(), EMPTY_RPC_OPTIONS)).andReturn(UPLOAD_ID);
     Capture<byte[]> capturedBuffer = Capture.newInstance(CaptureType.ALL);
     Capture<Long> capturedPosition = Capture.newInstance(CaptureType.ALL);
-    storageRpcMock.write(
-        eq(UPLOAD_ID),
-        capture(capturedBuffer),
-        eq(0),
-        captureLong(capturedPosition),
-        eq(DEFAULT_CHUNK_SIZE),
-        eq(false));
+    expect(
+            storageRpcMock.write(
+                eq(UPLOAD_ID),
+                capture(capturedBuffer),
+                eq(0),
+                captureLong(capturedPosition),
+                eq(DEFAULT_CHUNK_SIZE),
+                eq(false)))
+        .andReturn(null);
     expectLastCall().times(2);
     replay(storageRpcMock);
     ByteBuffer buffer1 = randomBuffer(DEFAULT_CHUNK_SIZE);
@@ -239,7 +280,10 @@ public class BlobWriteChannelTest {
   public void testSaveAndRestoreClosed() throws IOException {
     expect(storageRpcMock.open(BLOB_INFO.toPb(), EMPTY_RPC_OPTIONS)).andReturn(UPLOAD_ID);
     Capture<byte[]> capturedBuffer = Capture.newInstance();
-    storageRpcMock.write(eq(UPLOAD_ID), capture(capturedBuffer), eq(0), eq(0L), eq(0), eq(true));
+    expect(
+            storageRpcMock.write(
+                eq(UPLOAD_ID), capture(capturedBuffer), eq(0), eq(0L), eq(0), eq(true)))
+        .andReturn(UPDATED_BLOB);
     replay(storageRpcMock);
     writer = new BlobWriteChannel(options, BLOB_INFO, EMPTY_RPC_OPTIONS);
     writer.close();
@@ -283,8 +327,15 @@ public class BlobWriteChannelTest {
   public void testWriteWithSignedURLAndWithFlush() throws IOException {
     expect(storageRpcMock.open(SIGNED_URL)).andReturn(UPLOAD_ID);
     Capture<byte[]> capturedBuffer = Capture.newInstance();
-    storageRpcMock.write(
-        eq(UPLOAD_ID), capture(capturedBuffer), eq(0), eq(0L), eq(CUSTOM_CHUNK_SIZE), eq(false));
+    expect(
+            storageRpcMock.write(
+                eq(UPLOAD_ID),
+                capture(capturedBuffer),
+                eq(0),
+                eq(0L),
+                eq(CUSTOM_CHUNK_SIZE),
+                eq(false)))
+        .andReturn(null);
     replay(storageRpcMock);
     writer = new BlobWriteChannel(options, new URL(SIGNED_URL));
     writer.setChunkSize(CUSTOM_CHUNK_SIZE);
@@ -297,8 +348,15 @@ public class BlobWriteChannelTest {
   public void testWriteWithSignedURLAndFlush() throws IOException {
     expect(storageRpcMock.open(SIGNED_URL)).andReturn(UPLOAD_ID);
     Capture<byte[]> capturedBuffer = Capture.newInstance();
-    storageRpcMock.write(
-        eq(UPLOAD_ID), capture(capturedBuffer), eq(0), eq(0L), eq(DEFAULT_CHUNK_SIZE), eq(false));
+    expect(
+            storageRpcMock.write(
+                eq(UPLOAD_ID),
+                capture(capturedBuffer),
+                eq(0),
+                eq(0L),
+                eq(DEFAULT_CHUNK_SIZE),
+                eq(false)))
+        .andReturn(null);
     replay(storageRpcMock);
     writer = new BlobWriteChannel(options, new URL(SIGNED_URL));
     ByteBuffer[] buffers = new ByteBuffer[DEFAULT_CHUNK_SIZE / MIN_CHUNK_SIZE];
@@ -318,7 +376,10 @@ public class BlobWriteChannelTest {
   public void testCloseWithSignedURLWithoutFlush() throws IOException {
     expect(storageRpcMock.open(SIGNED_URL)).andReturn(UPLOAD_ID);
     Capture<byte[]> capturedBuffer = Capture.newInstance();
-    storageRpcMock.write(eq(UPLOAD_ID), capture(capturedBuffer), eq(0), eq(0L), eq(0), eq(true));
+    expect(
+            storageRpcMock.write(
+                eq(UPLOAD_ID), capture(capturedBuffer), eq(0), eq(0L), eq(0), eq(true)))
+        .andReturn(UPDATED_BLOB);
     replay(storageRpcMock);
     writer = new BlobWriteChannel(options, new URL(SIGNED_URL));
     assertTrue(writer.isOpen());
@@ -332,8 +393,15 @@ public class BlobWriteChannelTest {
     expect(storageRpcMock.open(SIGNED_URL)).andReturn(UPLOAD_ID);
     Capture<byte[]> capturedBuffer = Capture.newInstance();
     ByteBuffer buffer = randomBuffer(MIN_CHUNK_SIZE);
-    storageRpcMock.write(
-        eq(UPLOAD_ID), capture(capturedBuffer), eq(0), eq(0L), eq(MIN_CHUNK_SIZE), eq(true));
+    expect(
+            storageRpcMock.write(
+                eq(UPLOAD_ID),
+                capture(capturedBuffer),
+                eq(0),
+                eq(0L),
+                eq(MIN_CHUNK_SIZE),
+                eq(true)))
+        .andReturn(UPDATED_BLOB);
     replay(storageRpcMock);
     writer = new BlobWriteChannel(options, new URL(SIGNED_URL));
     assertTrue(writer.isOpen());
@@ -348,7 +416,10 @@ public class BlobWriteChannelTest {
   public void testWriteWithSignedURLClosed() throws IOException {
     expect(storageRpcMock.open(SIGNED_URL)).andReturn(UPLOAD_ID);
     Capture<byte[]> capturedBuffer = Capture.newInstance();
-    storageRpcMock.write(eq(UPLOAD_ID), capture(capturedBuffer), eq(0), eq(0L), eq(0), eq(true));
+    expect(
+            storageRpcMock.write(
+                eq(UPLOAD_ID), capture(capturedBuffer), eq(0), eq(0L), eq(0), eq(true)))
+        .andReturn(UPDATED_BLOB);
     replay(storageRpcMock);
     writer = new BlobWriteChannel(options, new URL(SIGNED_URL));
     writer.close();
@@ -365,13 +436,15 @@ public class BlobWriteChannelTest {
     expect(storageRpcMock.open(SIGNED_URL)).andReturn(UPLOAD_ID);
     Capture<byte[]> capturedBuffer = Capture.newInstance(CaptureType.ALL);
     Capture<Long> capturedPosition = Capture.newInstance(CaptureType.ALL);
-    storageRpcMock.write(
-        eq(UPLOAD_ID),
-        capture(capturedBuffer),
-        eq(0),
-        captureLong(capturedPosition),
-        eq(DEFAULT_CHUNK_SIZE),
-        eq(false));
+    expect(
+            storageRpcMock.write(
+                eq(UPLOAD_ID),
+                capture(capturedBuffer),
+                eq(0),
+                captureLong(capturedPosition),
+                eq(DEFAULT_CHUNK_SIZE),
+                eq(false)))
+        .andReturn(null);
     expectLastCall().times(2);
     replay(storageRpcMock);
     ByteBuffer buffer1 = randomBuffer(DEFAULT_CHUNK_SIZE);

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITStorageTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITStorageTest.java
@@ -3219,7 +3219,10 @@ public class ITStorageTest {
 
     Path tempFileFrom = Files.createTempFile("ITStorageTest_", ".tmp");
     Files.write(tempFileFrom, BLOB_BYTE_CONTENT);
-    storage.upload(blobInfo, tempFileFrom);
+    Blob blob = storage.upload(blobInfo, tempFileFrom);
+    assertEquals(BUCKET, blob.getBucket());
+    assertEquals(blobName, blob.getName());
+    assertEquals(BLOB_BYTE_CONTENT.length, (long) blob.getSize());
 
     Path tempFileTo = Files.createTempFile("ITStorageTest_", ".tmp");
     storage.get(blobId).downloadTo(tempFileTo);
@@ -3234,9 +3237,8 @@ public class ITStorageTest {
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
 
     ByteArrayInputStream content = new ByteArrayInputStream(BLOB_BYTE_CONTENT);
-    storage.upload(blobInfo, content, Storage.BlobWriteOption.encryptionKey(KEY));
+    Blob blob = storage.upload(blobInfo, content, Storage.BlobWriteOption.encryptionKey(KEY));
 
-    Blob blob = storage.get(blobId);
     try {
       blob.getContent();
       fail("StorageException was expected");


### PR DESCRIPTION
Changes:
- StorageRpc.write returns StorageObject instead of void
- Storage.upload() functions return Blob instead of void

