### PR TITLE
Postpolicy

### DIFF
--- a/google-cloud-storage/clirr-ignored-differences.xml
+++ b/google-cloud-storage/clirr-ignored-differences.xml
@@ -21,14 +21,4 @@
         <method>com.google.cloud.storage.BucketInfo$Builder deleteLifecycleRules()</method>
         <differenceType>7013</differenceType>
     </difference>
-    <difference>
-        <differenceType>7002</differenceType>
-        <className>com/google/cloud/storage/PostPolicyV4$PostFieldsV4$Builder</className>
-        <method>*.PostPolicyV4$PostFieldsV4$Builder AddCustomMetadataField(java.lang.String, java.lang.String)</method>
-    </difference>
-    <difference>
-        <differenceType>7002</differenceType>
-        <className>com/google/cloud/storage/PostPolicyV4$PostFieldsV4$Builder</className>
-        <method>*.PostPolicyV4$PostFieldsV4$Builder Expires(java.lang.String)</method>
-    </difference>
 </differences>

--- a/google-cloud-storage/clirr-ignored-differences.xml
+++ b/google-cloud-storage/clirr-ignored-differences.xml
@@ -21,4 +21,14 @@
         <method>com.google.cloud.storage.BucketInfo$Builder deleteLifecycleRules()</method>
         <differenceType>7013</differenceType>
     </difference>
+    <difference>
+        <differenceType>7002</differenceType>
+        <className>com/google/cloud/storage/PostPolicyV4$PostFieldsV4$Builder</className>
+        <method>*.PostPolicyV4$PostFieldsV4$Builder AddCustomMetadataField(java.lang.String, java.lang.String)</method>
+    </difference>
+    <difference>
+        <differenceType>7002</differenceType>
+        <className>com/google/cloud/storage/PostPolicyV4$PostFieldsV4$Builder</className>
+        <method>*.PostPolicyV4$PostFieldsV4$Builder Expires(java.lang.String)</method>
+    </difference>
 </differences>

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/PostPolicyV4.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/PostPolicyV4.java
@@ -85,6 +85,7 @@ public final class PostPolicyV4 {
     }
 
     public static class Builder {
+      private static final String CUSTOM_FIELD_PREFIX = "x-goog-meta-";
       private final Map<String, String> fieldsMap;
 
       private Builder() {
@@ -145,6 +146,9 @@ public final class PostPolicyV4 {
       }
 
       public Builder addCustomMetadataField(String field, String value) {
+        if (!field.startsWith(CUSTOM_FIELD_PREFIX)) {
+          field = CUSTOM_FIELD_PREFIX + value;
+        }
         fieldsMap.put(field, value);
         return this;
       }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/PostPolicyV4.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/PostPolicyV4.java
@@ -31,8 +31,8 @@ import java.util.Set;
  * @see <a href="https://cloud.google.com/storage/docs/xml-api/post-object">POST Object</a>
  */
 public final class PostPolicyV4 {
-  private String url;
-  private Map<String, String> fields;
+  private final String url;
+  private final Map<String, String> fields;
 
   private PostPolicyV4(String url, Map<String, String> fields) {
     this.url = url;
@@ -58,7 +58,7 @@ public final class PostPolicyV4 {
    *     Object Form fields</a>
    */
   public static final class PostFieldsV4 {
-    private Map<String, String> fieldsMap;
+    private final Map<String, String> fieldsMap;
 
     private PostFieldsV4(Builder builder) {
       this.fieldsMap = builder.fieldsMap;
@@ -76,15 +76,23 @@ public final class PostPolicyV4 {
       return new Builder();
     }
 
+    public Builder toBuilder() {
+      return new Builder(fieldsMap);
+    }
+
     public Map<String, String> getFieldsMap() {
       return fieldsMap;
     }
 
     public static class Builder {
-      private Map<String, String> fieldsMap;
+      private final Map<String, String> fieldsMap;
 
       private Builder() {
-        fieldsMap = new HashMap<>();
+        this(new HashMap<String, String>());
+      }
+
+      private Builder(Map<String, String> fieldsMap) {
+        this.fieldsMap = fieldsMap;
       }
 
       public PostFieldsV4 build() {
@@ -121,7 +129,7 @@ public final class PostPolicyV4 {
         return this;
       }
 
-      public Builder Expires(String expires) {
+      public Builder setExpires(String expires) {
         fieldsMap.put("expires", expires);
         return this;
       }
@@ -136,8 +144,8 @@ public final class PostPolicyV4 {
         return this;
       }
 
-      public Builder AddCustomMetadataField(String field, String value) {
-        fieldsMap.put("x-goog-meta-" + field, value);
+      public Builder addCustomMetadataField(String field, String value) {
+        fieldsMap.put(field, value);
         return this;
       }
     }
@@ -270,8 +278,8 @@ public final class PostPolicyV4 {
    *     Policy document</a>
    */
   public static final class PostPolicyV4Document {
-    private String expiration;
-    private PostConditionsV4 conditions;
+    private final String expiration;
+    private final PostConditionsV4 conditions;
 
     private PostPolicyV4Document(String expiration, PostConditionsV4 conditions) {
       this.expiration = expiration;
@@ -363,9 +371,9 @@ public final class PostPolicyV4 {
    *     Policy document</a>
    */
   static final class ConditionV4 {
-    ConditionV4Type type;
-    String operand1;
-    String operand2;
+    final ConditionV4Type type;
+    final String operand1;
+    final String operand2;
 
     private ConditionV4(ConditionV4Type type, String operand1, String operand2) {
       this.type = type;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/PostPolicyV4.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/PostPolicyV4.java
@@ -122,9 +122,7 @@ public final class PostPolicyV4 {
         return this;
       }
 
-      /**
-       * @deprecated use {@link #setExpires(String)}
-       */
+      /** @deprecated use {@link #setExpires(String)} */
       @Deprecated
       public Builder Expires(String expires) {
         return setExpires(expires);
@@ -145,9 +143,7 @@ public final class PostPolicyV4 {
         return this;
       }
 
-      /**
-       * @deprecated use {@link #addCustomMetadataField(String, String)}
-       */
+      /** @deprecated use {@link #addCustomMetadataField(String, String)} */
       @Deprecated
       public Builder AddCustomMetadataField(String field, String value) {
         return addCustomMetadataField(field, value);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/PostPolicyV4.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/PostPolicyV4.java
@@ -76,10 +76,6 @@ public final class PostPolicyV4 {
       return new Builder();
     }
 
-    public Builder toBuilder() {
-      return new Builder(fieldsMap);
-    }
-
     public Map<String, String> getFieldsMap() {
       return fieldsMap;
     }
@@ -89,11 +85,7 @@ public final class PostPolicyV4 {
       private final Map<String, String> fieldsMap;
 
       private Builder() {
-        this(new HashMap<String, String>());
-      }
-
-      private Builder(Map<String, String> fieldsMap) {
-        this.fieldsMap = fieldsMap;
+        this.fieldsMap = new HashMap<>();
       }
 
       public PostFieldsV4 build() {
@@ -130,6 +122,14 @@ public final class PostPolicyV4 {
         return this;
       }
 
+      /**
+       * @deprecated use {@link #setExpires(String)}
+       */
+      @Deprecated
+      public Builder Expires(String expires) {
+        return setExpires(expires);
+      }
+
       public Builder setExpires(String expires) {
         fieldsMap.put("expires", expires);
         return this;
@@ -143,6 +143,14 @@ public final class PostPolicyV4 {
       public Builder setSuccessActionStatus(int successActionStatus) {
         fieldsMap.put("success_action_status", "" + successActionStatus);
         return this;
+      }
+
+      /**
+       * @deprecated use {@link #addCustomMetadataField(String, String)}
+       */
+      @Deprecated
+      public Builder AddCustomMetadataField(String field, String value) {
+        return addCustomMetadataField(field, value);
       }
 
       public Builder addCustomMetadataField(String field, String value) {


### PR DESCRIPTION
- method renamed in `PostPolicyV4.PostFieldsV4.Builder`:
  - `AddCustomMetadataField` -> `addCustomMetadataField`
  - `Exists` -> `setExists`
- new method in `PostPolicyV4.PostFieldsV4`: `toBuilder()`
- `PostPolicyV4.PostFieldsV4.Builder.addCustomMetadataField()` allows to add prefixed an not prefixed custom fields
- class fields are declared `final` when possible

