### PR TITLE
test: ITStorageTest cleanup

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITStorageTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITStorageTest.java
@@ -135,7 +135,6 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -150,6 +149,7 @@ public class ITStorageTest {
       Metadata.Key.of("x-goog-request-params", Metadata.ASCII_STRING_MARSHALLER);
   private static final Logger log = Logger.getLogger(ITStorageTest.class.getName());
   private static final String BUCKET = RemoteStorageHelper.generateBucketName();
+  private static final String BUCKET_REQUESTER_PAYS = RemoteStorageHelper.generateBucketName();
   private static final String CONTENT_TYPE = "text/plain";
   private static final byte[] BLOB_BYTE_CONTENT = {0xD, 0xE, 0xA, 0xD};
   private static final String BLOB_STRING_CONTENT = "Hello Google Cloud Storage!";
@@ -212,15 +212,16 @@ public class ITStorageTest {
                         LifecycleCondition.newBuilder().setAge(1).build())))
             .build());
 
+    storage.create(BucketInfo.newBuilder(BUCKET_REQUESTER_PAYS).build());
+
     // Prepare KMS KeyRing for CMEK tests
     prepareKmsKeys();
   }
 
-  @Before
-  public void beforeEach() {
+  private static void unsetRequesterPays() {
     Bucket remoteBucket =
         storage.get(
-            BUCKET,
+            BUCKET_REQUESTER_PAYS,
             Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING),
             Storage.BucketGetOption.userProject(storage.getOptions().getProjectId()));
     // Disable requester pays in case a test fails to clean up.
@@ -246,6 +247,8 @@ public class ITStorageTest {
       if (!wasDeleted && log.isLoggable(Level.WARNING)) {
         log.log(Level.WARNING, "Deletion of bucket {0} timed out, bucket is not empty", BUCKET);
       }
+      unsetRequesterPays();
+      RemoteStorageHelper.forceDelete(storage, BUCKET_REQUESTER_PAYS, 5, TimeUnit.SECONDS);
     }
   }
 
@@ -912,22 +915,24 @@ public class ITStorageTest {
 
   @Test(timeout = 7500)
   public void testListBlobRequesterPays() throws InterruptedException {
+    unsetRequesterPays();
     BlobInfo blob1 =
-        BlobInfo.newBuilder(BUCKET, "test-list-blobs-empty-selected-fields-blob1")
+        BlobInfo.newBuilder(BUCKET_REQUESTER_PAYS, "test-list-blobs-empty-selected-fields-blob1")
             .setContentType(CONTENT_TYPE)
             .build();
     assertNotNull(storage.create(blob1));
 
     // Test listing a Requester Pays bucket.
     Bucket remoteBucket =
-        storage.get(BUCKET, Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING));
-    assertFalse(remoteBucket.requesterPays());
+        storage.get(BUCKET_REQUESTER_PAYS, Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING));
+
+    assertTrue(remoteBucket.requesterPays() == null || !remoteBucket.requesterPays());
     remoteBucket = remoteBucket.toBuilder().setRequesterPays(true).build();
     Bucket updatedBucket = storage.update(remoteBucket);
     assertTrue(updatedBucket.requesterPays());
     try {
       storage.list(
-          BUCKET,
+          BUCKET_REQUESTER_PAYS,
           Storage.BlobListOption.prefix("test-list-blobs-empty-selected-fields-blob"),
           Storage.BlobListOption.fields(),
           Storage.BlobListOption.userProject("fakeBillingProjectId"));
@@ -940,7 +945,7 @@ public class ITStorageTest {
     while (true) {
       Page<Blob> page =
           storage.list(
-              BUCKET,
+              BUCKET_REQUESTER_PAYS,
               Storage.BlobListOption.prefix("test-list-blobs-empty-selected-fields-blob"),
               Storage.BlobListOption.fields(),
               Storage.BlobListOption.userProject(projectId));
@@ -2232,6 +2237,7 @@ public class ITStorageTest {
 
   @Test
   public void testBucketAcl() {
+    unsetRequesterPays();
     testBucketAclRequesterPays(true);
     testBucketAclRequesterPays(false);
   }
@@ -2239,7 +2245,7 @@ public class ITStorageTest {
   private void testBucketAclRequesterPays(boolean requesterPays) {
     if (requesterPays) {
       Bucket remoteBucket =
-          storage.get(BUCKET, Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING));
+          storage.get(BUCKET_REQUESTER_PAYS, Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING));
       assertNull(remoteBucket.requesterPays());
       remoteBucket = remoteBucket.toBuilder().setRequesterPays(true).build();
       Bucket updatedBucket = storage.update(remoteBucket);
@@ -2253,22 +2259,22 @@ public class ITStorageTest {
             ? new Storage.BucketSourceOption[] {Storage.BucketSourceOption.userProject(projectId)}
             : new Storage.BucketSourceOption[] {};
 
-    assertNull(storage.getAcl(BUCKET, User.ofAllAuthenticatedUsers(), bucketOptions));
-    assertFalse(storage.deleteAcl(BUCKET, User.ofAllAuthenticatedUsers(), bucketOptions));
+    assertNull(storage.getAcl(BUCKET_REQUESTER_PAYS, User.ofAllAuthenticatedUsers(), bucketOptions));
+    assertFalse(storage.deleteAcl(BUCKET_REQUESTER_PAYS, User.ofAllAuthenticatedUsers(), bucketOptions));
     Acl acl = Acl.of(User.ofAllAuthenticatedUsers(), Role.READER);
-    assertNotNull(storage.createAcl(BUCKET, acl, bucketOptions));
+    assertNotNull(storage.createAcl(BUCKET_REQUESTER_PAYS, acl, bucketOptions));
     Acl updatedAcl =
-        storage.updateAcl(BUCKET, acl.toBuilder().setRole(Role.WRITER).build(), bucketOptions);
+        storage.updateAcl(BUCKET_REQUESTER_PAYS, acl.toBuilder().setRole(Role.WRITER).build(), bucketOptions);
     assertEquals(Role.WRITER, updatedAcl.getRole());
     Set<Acl> acls = new HashSet<>();
-    acls.addAll(storage.listAcls(BUCKET, bucketOptions));
+    acls.addAll(storage.listAcls(BUCKET_REQUESTER_PAYS, bucketOptions));
     assertTrue(acls.contains(updatedAcl));
-    assertTrue(storage.deleteAcl(BUCKET, User.ofAllAuthenticatedUsers(), bucketOptions));
-    assertNull(storage.getAcl(BUCKET, User.ofAllAuthenticatedUsers(), bucketOptions));
+    assertTrue(storage.deleteAcl(BUCKET_REQUESTER_PAYS, User.ofAllAuthenticatedUsers(), bucketOptions));
+    assertNull(storage.getAcl(BUCKET_REQUESTER_PAYS, User.ofAllAuthenticatedUsers(), bucketOptions));
     if (requesterPays) {
       Bucket remoteBucket =
           storage.get(
-              BUCKET,
+              BUCKET_REQUESTER_PAYS,
               Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING),
               Storage.BucketGetOption.userProject(projectId));
       assertTrue(remoteBucket.requesterPays());
@@ -2460,80 +2466,73 @@ public class ITStorageTest {
 
   @Test
   public void testBucketPolicyV1RequesterPays() throws ExecutionException, InterruptedException {
-    String bucketName = RemoteStorageHelper.generateBucketName();
-    storage.create(BucketInfo.newBuilder(bucketName).build());
+    Bucket bucketDefault =
+        storage.get(
+            BUCKET_REQUESTER_PAYS, Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING));
+    assertTrue(bucketDefault.requesterPays() == null || !bucketDefault.requesterPays());
 
-    try {
-      Bucket bucketDefault =
-          storage.get(
-              bucketName, Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING));
-      assertNull(bucketDefault.requesterPays());
+    Bucket bucketTrue = storage.update(bucketDefault.toBuilder().setRequesterPays(true).build());
+    assertTrue(bucketTrue.requesterPays());
 
-      Bucket bucketTrue = storage.update(bucketDefault.toBuilder().setRequesterPays(true).build());
-      assertTrue(bucketTrue.requesterPays());
+    String projectId = remoteStorageHelper.getOptions().getProjectId();
 
-      String projectId = remoteStorageHelper.getOptions().getProjectId();
+    Storage.BucketSourceOption[] bucketOptions =
+        new Storage.BucketSourceOption[] {Storage.BucketSourceOption.userProject(projectId)};
+    Identity projectOwner = Identity.projectOwner(projectId);
+    Identity projectEditor = Identity.projectEditor(projectId);
+    Identity projectViewer = Identity.projectViewer(projectId);
+    Map<com.google.cloud.Role, Set<Identity>> bindingsWithoutPublicRead =
+        ImmutableMap.of(
+            StorageRoles.legacyBucketOwner(),
+            new HashSet<>(Arrays.asList(projectOwner, projectEditor)),
+            StorageRoles.legacyBucketReader(),
+            (Set<Identity>) new HashSet<>(Collections.singleton(projectViewer)));
+    Map<com.google.cloud.Role, Set<Identity>> bindingsWithPublicRead =
+        ImmutableMap.of(
+            StorageRoles.legacyBucketOwner(),
+            new HashSet<>(Arrays.asList(projectOwner, projectEditor)),
+            StorageRoles.legacyBucketReader(),
+            new HashSet<>(Collections.singleton(projectViewer)),
+            StorageRoles.legacyObjectReader(),
+            (Set<Identity>) new HashSet<>(Collections.singleton(Identity.allUsers())));
 
-      Storage.BucketSourceOption[] bucketOptions =
-          new Storage.BucketSourceOption[] {Storage.BucketSourceOption.userProject(projectId)};
-      Identity projectOwner = Identity.projectOwner(projectId);
-      Identity projectEditor = Identity.projectEditor(projectId);
-      Identity projectViewer = Identity.projectViewer(projectId);
-      Map<com.google.cloud.Role, Set<Identity>> bindingsWithoutPublicRead =
-          ImmutableMap.of(
-              StorageRoles.legacyBucketOwner(),
-              new HashSet<>(Arrays.asList(projectOwner, projectEditor)),
-              StorageRoles.legacyBucketReader(),
-              (Set<Identity>) new HashSet<>(Collections.singleton(projectViewer)));
-      Map<com.google.cloud.Role, Set<Identity>> bindingsWithPublicRead =
-          ImmutableMap.of(
-              StorageRoles.legacyBucketOwner(),
-              new HashSet<>(Arrays.asList(projectOwner, projectEditor)),
-              StorageRoles.legacyBucketReader(),
-              new HashSet<>(Collections.singleton(projectViewer)),
-              StorageRoles.legacyObjectReader(),
-              (Set<Identity>) new HashSet<>(Collections.singleton(Identity.allUsers())));
+    // Validate getting policy.
+    Policy currentPolicy = storage.getIamPolicy(BUCKET_REQUESTER_PAYS, bucketOptions);
+    assertEquals(bindingsWithoutPublicRead, currentPolicy.getBindings());
 
-      // Validate getting policy.
-      Policy currentPolicy = storage.getIamPolicy(bucketName, bucketOptions);
-      assertEquals(bindingsWithoutPublicRead, currentPolicy.getBindings());
+    // Validate updating policy.
+    Policy updatedPolicy =
+        storage.setIamPolicy(
+            BUCKET_REQUESTER_PAYS,
+            currentPolicy
+                .toBuilder()
+                .addIdentity(StorageRoles.legacyObjectReader(), Identity.allUsers())
+                .build(),
+            bucketOptions);
+    assertEquals(bindingsWithPublicRead, updatedPolicy.getBindings());
+    Policy revertedPolicy =
+        storage.setIamPolicy(
+            BUCKET_REQUESTER_PAYS,
+            updatedPolicy
+                .toBuilder()
+                .removeIdentity(StorageRoles.legacyObjectReader(), Identity.allUsers())
+                .build(),
+            bucketOptions);
+    assertEquals(bindingsWithoutPublicRead, revertedPolicy.getBindings());
 
-      // Validate updating policy.
-      Policy updatedPolicy =
-          storage.setIamPolicy(
-              bucketName,
-              currentPolicy
-                  .toBuilder()
-                  .addIdentity(StorageRoles.legacyObjectReader(), Identity.allUsers())
-                  .build(),
-              bucketOptions);
-      assertEquals(bindingsWithPublicRead, updatedPolicy.getBindings());
-      Policy revertedPolicy =
-          storage.setIamPolicy(
-              bucketName,
-              updatedPolicy
-                  .toBuilder()
-                  .removeIdentity(StorageRoles.legacyObjectReader(), Identity.allUsers())
-                  .build(),
-              bucketOptions);
-      assertEquals(bindingsWithoutPublicRead, revertedPolicy.getBindings());
-
-      // Validate testing permissions.
-      List<Boolean> expectedPermissions = ImmutableList.of(true, true);
-      assertEquals(
-          expectedPermissions,
-          storage.testIamPermissions(
-              bucketName,
-              ImmutableList.of("storage.buckets.getIamPolicy", "storage.buckets.setIamPolicy"),
-              bucketOptions));
-      Bucket bucketFalse =
-          storage.update(
-              bucketTrue.toBuilder().setRequesterPays(false).build(),
-              Storage.BucketTargetOption.userProject(projectId));
-      assertFalse(bucketFalse.requesterPays());
-    } finally {
-      RemoteStorageHelper.forceDelete(storage, bucketName, 5, TimeUnit.SECONDS);
-    }
+    // Validate testing permissions.
+    List<Boolean> expectedPermissions = ImmutableList.of(true, true);
+    assertEquals(
+        expectedPermissions,
+        storage.testIamPermissions(
+            BUCKET_REQUESTER_PAYS,
+            ImmutableList.of("storage.buckets.getIamPolicy", "storage.buckets.setIamPolicy"),
+            bucketOptions));
+    Bucket bucketFalse =
+        storage.update(
+            bucketTrue.toBuilder().setRequesterPays(false).build(),
+            Storage.BucketTargetOption.userProject(projectId));
+    assertFalse(bucketFalse.requesterPays());
   }
 
   @Test
@@ -2763,9 +2762,10 @@ public class ITStorageTest {
 
   @Test
   public void testUpdateBucketRequesterPays() {
+    unsetRequesterPays();
     Bucket remoteBucket =
-        storage.get(BUCKET, Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING));
-    assertFalse(remoteBucket.requesterPays());
+        storage.get(BUCKET_REQUESTER_PAYS, Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING));
+    assertTrue(remoteBucket.requesterPays() == null || !remoteBucket.requesterPays());
     remoteBucket = remoteBucket.toBuilder().setRequesterPays(true).build();
     Bucket updatedBucket = storage.update(remoteBucket);
     assertTrue(updatedBucket.requesterPays());
@@ -2776,7 +2776,7 @@ public class ITStorageTest {
     Blob remoteBlob = updatedBucket.create(blobName, BLOB_BYTE_CONTENT, option);
     assertNotNull(remoteBlob);
     byte[] readBytes =
-        storage.readAllBytes(BUCKET, blobName, Storage.BlobSourceOption.userProject(projectId));
+        storage.readAllBytes(BUCKET_REQUESTER_PAYS, blobName, Storage.BlobSourceOption.userProject(projectId));
     assertArrayEquals(BLOB_BYTE_CONTENT, readBytes);
     remoteBucket = remoteBucket.toBuilder().setRequesterPays(false).build();
     updatedBucket = storage.update(remoteBucket, Storage.BucketTargetOption.userProject(projectId));
@@ -3022,7 +3022,7 @@ public class ITStorageTest {
     } catch (StorageException ex) {
       // expected
     } finally {
-      remoteBlob.toBuilder().setEventBasedHold(false).build().update();
+      remoteBlob.toBuilder().setTemporaryHold(false).build().update();
     }
   }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITStorageTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITStorageTest.java
@@ -924,7 +924,9 @@ public class ITStorageTest {
 
     // Test listing a Requester Pays bucket.
     Bucket remoteBucket =
-        storage.get(BUCKET_REQUESTER_PAYS, Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING));
+        storage.get(
+            BUCKET_REQUESTER_PAYS,
+            Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING));
 
     assertTrue(remoteBucket.requesterPays() == null || !remoteBucket.requesterPays());
     remoteBucket = remoteBucket.toBuilder().setRequesterPays(true).build();
@@ -2245,8 +2247,10 @@ public class ITStorageTest {
   private void testBucketAclRequesterPays(boolean requesterPays) {
     if (requesterPays) {
       Bucket remoteBucket =
-          storage.get(BUCKET_REQUESTER_PAYS, Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING));
-      assertNull(remoteBucket.requesterPays());
+          storage.get(
+              BUCKET_REQUESTER_PAYS,
+              Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING));
+      assertTrue(remoteBucket.requesterPays() == null || !remoteBucket.requesterPays());
       remoteBucket = remoteBucket.toBuilder().setRequesterPays(true).build();
       Bucket updatedBucket = storage.update(remoteBucket);
       assertTrue(updatedBucket.requesterPays());
@@ -2259,18 +2263,23 @@ public class ITStorageTest {
             ? new Storage.BucketSourceOption[] {Storage.BucketSourceOption.userProject(projectId)}
             : new Storage.BucketSourceOption[] {};
 
-    assertNull(storage.getAcl(BUCKET_REQUESTER_PAYS, User.ofAllAuthenticatedUsers(), bucketOptions));
-    assertFalse(storage.deleteAcl(BUCKET_REQUESTER_PAYS, User.ofAllAuthenticatedUsers(), bucketOptions));
+    assertNull(
+        storage.getAcl(BUCKET_REQUESTER_PAYS, User.ofAllAuthenticatedUsers(), bucketOptions));
+    assertFalse(
+        storage.deleteAcl(BUCKET_REQUESTER_PAYS, User.ofAllAuthenticatedUsers(), bucketOptions));
     Acl acl = Acl.of(User.ofAllAuthenticatedUsers(), Role.READER);
     assertNotNull(storage.createAcl(BUCKET_REQUESTER_PAYS, acl, bucketOptions));
     Acl updatedAcl =
-        storage.updateAcl(BUCKET_REQUESTER_PAYS, acl.toBuilder().setRole(Role.WRITER).build(), bucketOptions);
+        storage.updateAcl(
+            BUCKET_REQUESTER_PAYS, acl.toBuilder().setRole(Role.WRITER).build(), bucketOptions);
     assertEquals(Role.WRITER, updatedAcl.getRole());
     Set<Acl> acls = new HashSet<>();
     acls.addAll(storage.listAcls(BUCKET_REQUESTER_PAYS, bucketOptions));
     assertTrue(acls.contains(updatedAcl));
-    assertTrue(storage.deleteAcl(BUCKET_REQUESTER_PAYS, User.ofAllAuthenticatedUsers(), bucketOptions));
-    assertNull(storage.getAcl(BUCKET_REQUESTER_PAYS, User.ofAllAuthenticatedUsers(), bucketOptions));
+    assertTrue(
+        storage.deleteAcl(BUCKET_REQUESTER_PAYS, User.ofAllAuthenticatedUsers(), bucketOptions));
+    assertNull(
+        storage.getAcl(BUCKET_REQUESTER_PAYS, User.ofAllAuthenticatedUsers(), bucketOptions));
     if (requesterPays) {
       Bucket remoteBucket =
           storage.get(
@@ -2466,9 +2475,11 @@ public class ITStorageTest {
 
   @Test
   public void testBucketPolicyV1RequesterPays() throws ExecutionException, InterruptedException {
+    unsetRequesterPays();
     Bucket bucketDefault =
         storage.get(
-            BUCKET_REQUESTER_PAYS, Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING));
+            BUCKET_REQUESTER_PAYS,
+            Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING));
     assertTrue(bucketDefault.requesterPays() == null || !bucketDefault.requesterPays());
 
     Bucket bucketTrue = storage.update(bucketDefault.toBuilder().setRequesterPays(true).build());
@@ -2764,7 +2775,9 @@ public class ITStorageTest {
   public void testUpdateBucketRequesterPays() {
     unsetRequesterPays();
     Bucket remoteBucket =
-        storage.get(BUCKET_REQUESTER_PAYS, Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING));
+        storage.get(
+            BUCKET_REQUESTER_PAYS,
+            Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING));
     assertTrue(remoteBucket.requesterPays() == null || !remoteBucket.requesterPays());
     remoteBucket = remoteBucket.toBuilder().setRequesterPays(true).build();
     Bucket updatedBucket = storage.update(remoteBucket);
@@ -2776,7 +2789,8 @@ public class ITStorageTest {
     Blob remoteBlob = updatedBucket.create(blobName, BLOB_BYTE_CONTENT, option);
     assertNotNull(remoteBlob);
     byte[] readBytes =
-        storage.readAllBytes(BUCKET_REQUESTER_PAYS, blobName, Storage.BlobSourceOption.userProject(projectId));
+        storage.readAllBytes(
+            BUCKET_REQUESTER_PAYS, blobName, Storage.BlobSourceOption.userProject(projectId));
     assertArrayEquals(BLOB_BYTE_CONTENT, readBytes);
     remoteBucket = remoteBucket.toBuilder().setRequesterPays(false).build();
     updatedBucket = storage.update(remoteBucket, Storage.BucketTargetOption.userProject(projectId));


### PR DESCRIPTION
The following problems have been detected:

- `testListBlobRequesterPays`, `testUpdateBucketRequesterPays` - make independent from other tests
- `testAttemptDeletionObjectTemporaryHold` - restoring operation corrected
- `testBucketAcl`, `testUpdateBucketRequesterPays` , `testBucketPolicyV1RequesterPays` - updated to use the dedicated bucket
- @Before code can now be invoked only by a few tests, not all
